### PR TITLE
Added basic docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+
+RUN pip install --no-cache-dir minitor
+WORKDIR /app
+COPY config.yml /app/config.yml
+CMD minitor

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ make run
 
 It will read the contents of `config.yml` and begin its loop. You could also run it directly and provide a new config file via the `--config` argument.
 
+
+#### Docker
+
+You can pull this repository directly from Docker:
+
+`docker pull kevineaton/minitor`
+
+The Docker image uses a default `config.yml` that simply pings a server every 30 seconds with exponential backup. This is likely not what you want, so when you run the Docker image, you should supply your own `config.yml` file:
+
+`docker run -v $PWD/config.yml:/app/config.yml kevineaton/minitor`
+
+Note that the image uses the version of minitor in `pip` and does not build from source.
+
 ### Configuring
 
 In this repo, you can explore the `sample-config.yml` file for an example, but the general structure is as follows. It should be noted that environment variable interpolation happens on load of the YAML file. Also, when alerts are executed, they will be passed through Python's format function with arguments for some attributes of the Monitor. Currently this is limited to `{monitor_name}`.


### PR DESCRIPTION
I added basic Docker support since we run all of our tools in Docker. It's fairly basic. Right now, I pushed the image to https://hub.docker.com/r/kevineaton/minitor/    Obviously, you will likely want to put the image under your own name. If you do, let me know and I can pull mine off the registry. Don't forget to update the README if you do that though.

Thanks for the tool! I look forward to using it more as it is a lot easier to use to integrate with Cachet.