### PR TITLE
Added new function to issue a alert if the service is up again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ docs/_build/
 target/
 
 config.yml
+
+# IDE (IntelliJ IDEA)
+.idea/
+*.iml
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:2.7
+LABEL AUTHOR="SeaLife"
+
+RUN mkdir /app
+
+COPY . /tmp/minitor-bin/
+COPY docker-assets/entrypoint.sh /root/entrypoint.sh
+
+RUN chmod +x /root/entrypoint.sh
+
+WORKDIR /tmp/minitor-bin
+
+RUN pip install virtualenv tox yamlenv
+RUN python setup.py build
+RUN python setup.py install
+
+WORKDIR /app
+
+CMD [ "/root/entrypoint.sh" ]

--- a/docker-assets/entrypoint.sh
+++ b/docker-assets/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+## Allow the user to create a autorun-file to install more packages via apt for example
+if [ -f /app/autorun.sh ]; then
+  if [ ! -f /app/.autorun_ok ]; then
+    /app/autorun.sh
+    touch /app/.autorun_ok
+  fi
+fi
+
+minitor --config /app/config.yml

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0

--- a/tests/monitor_test.py
+++ b/tests/monitor_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from minitor.main import InvalidMonitorException
-from minitor.main import MinitorAlert
+from minitor.main import MinitorAlertEvent
 from minitor.main import Monitor
 from minitor.main import validate_monitor_settings
 
@@ -46,7 +46,7 @@ class TestMonitor(object):
             monitor.failure()
 
         # this time should raise an alert
-        with pytest.raises(MinitorAlert):
+        with pytest.raises(MinitorAlertEvent):
             monitor.failure()
 
     @pytest.mark.parametrize(
@@ -68,7 +68,7 @@ class TestMonitor(object):
             monitor.failure()
 
         # this time should raise an alert
-        with pytest.raises(MinitorAlert):
+        with pytest.raises(MinitorAlertEvent):
             monitor.failure()
 
         # fail a bunch more times until the next alert
@@ -76,7 +76,7 @@ class TestMonitor(object):
             monitor.failure()
 
         # this failure should alert now
-        with pytest.raises(MinitorAlert):
+        with pytest.raises(MinitorAlertEvent):
             monitor.failure()
 
     def test_monitor_alert_every_exponential(self, monitor):
@@ -88,7 +88,7 @@ class TestMonitor(object):
 
         for i in range(failure_count):
             if i + 1 in expect_failures_on:
-                with pytest.raises(MinitorAlert):
+                with pytest.raises(MinitorAlertEvent):
                     monitor.failure()
             else:
                 monitor.failure()


### PR DESCRIPTION
Hey there,

i've added a new function to run a alert if the service is up again.

```check_interval: 30

monitors:
  - name: My Website
    command: [ 'curl', 'https://minitor.mon' ]
    alerts: [ log, email, sms ]
    notify_up: [ sms_up, email_up ]
    check_interval: 30
    alert_after: 3
    alert_every: -1 # Defaults to -1 for exponential backoff

alerts:
  email:
    command: [ sendmail, "me@minitor.mon",  "Failure: {monitor_name}",  "This thing failed!" ]
  email_up:
    command: [ sendmail, "me@minitor.mon",  "Success: {monitor_name}",  "Service is back online! Yay!" ]
  mailgun:
    command: >
      curl -s -X POST
      -F subject="Alert! {monitor_name} failed"
      -F from="Minitor <minitor@minitor.mon>"
      -F to=me@minitor.mon
      -F text="Our monitor failed"
      https://api.mailgun.net/v3/minitor.mon/messages
      -u "api:${MAILGUN_API_KEY}"
  sms:
    command: >
      curl -s -X POST -F "Body=Failure: {monitor_name} has failed"
      -F "From=${AVAILABLE_NUMBER}" -F "To=${MY_PHONE}"
      "https://api.twilio.com/2010-04-01/Accounts/${ACCOUNT_SID}/Messages"
      -u "${ACCOUNT_SID}:${AUTH_TOKEN}"
  sms_up:
    command: >
      curl -s -X POST -F "Body=Failure: {monitor_name} is back online! :)"
      -F "From=${AVAILABLE_NUMBER}" -F "To=${MY_PHONE}"
      "https://api.twilio.com/2010-04-01/Accounts/${ACCOUNT_SID}/Messages"
      -u "${ACCOUNT_SID}:${AUTH_TOKEN}"

# federation:
#   - location: https://host1.com
#     client_key: keyfromhost1
#     server_key: keyhost1uses
#     alerts: [ sms ]

```

The sample config should clearify what i did.

Regards
SeaLife